### PR TITLE
chore: downgrade `nokogiri`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
     minitest (5.25.1)
-    nokogiri (1.16.7)
+    nokogiri (1.15.6)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     parallel (1.19.1)
@@ -119,4 +119,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.0.2
+   2.4.9


### PR DESCRIPTION
The current version of `nokogiri` requires at least Ruby 3.0 but we test against Ruby 2.7 - this does technically reintroduce a vulnerability (GHSA-r95h-9x8f-r3f7) which has only been patched in v1.16, but we can deal with that once we've gotten CI passing again